### PR TITLE
Fix unintended unfreezing of all cells when opening a notebook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
 
     - name: Setup pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-3.9-${{ hashFiles('package.json') }}
@@ -35,7 +35,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
     - name: Setup yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/src/CellExtension.ts
+++ b/src/CellExtension.ts
@@ -24,10 +24,19 @@ import { getCellState, setCellState } from './cell-state-utils';
 export class CellExtension
   implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>
 {
+  private isNotebookRevealed = false;
+
   createNew(
     widget: NotebookPanel,
     context: DocumentRegistry.IContext<INotebookModel>
   ): void | IDisposable {
+    void widget.revealed.then(() => {
+      if (widget.isDisposed) {
+        return;
+      }
+      console.log('NotebookPanel revealed and ready');
+      this.isNotebookRevealed = true;
+    });
     widget.content.model?.cells.changed.connect((_, args) => {
       if (['add'].includes(args.type)) {
         args.newValues.forEach(cellModel => {
@@ -54,6 +63,11 @@ export class CellExtension
         });
       }
       if (['add', 'set'].includes(args.type)) {
+        if (!this.isNotebookRevealed) {
+          console.log(
+            'NotebookPanel not yet revealed, skipping cell processing'
+          );
+        }
         args.newValues.forEach(c =>
           onCellAdded(c, widget.content, context.sessionContext)
         );
@@ -143,6 +157,10 @@ function onCodeCellAdded(
   if (!state.frozen && !state.read_only) {
     return;
   }
+  console.log(
+    'Unfreeze: Code cell added - automatically unfreezing cell',
+    cell.id
+  );
   setCellState(cell, {
     frozen: false,
     read_only: false


### PR DESCRIPTION
This Pull Request addresses an issue where all cells in a notebook were unintentionally unfrozen upon opening.
The root cause was a shared event handler originally intended to set newly pasted cells to the "unfrozen" state. This handler was also triggered during notebook loading, when existing cells were being initialized.
To resolve this, the fix ensures that any such events fired before the notebook is fully rendered are ignored. As a result, only newly added cells will be unfrozen, while preexisting cells remain unaffected upon notebook load.