### PR TITLE
fix: use correct class name in notebook cell assertion

### DIFF
--- a/ui-tests/tests/lc_run_through.spec.ts
+++ b/ui-tests/tests/lc_run_through.spec.ts
@@ -60,7 +60,7 @@ test('should work run-through button and show summary of outputs in collapsed he
   await expect(cells.nth(1)).toHaveClass(/run-through-code-result__error/);
   // icon3 (Gray)
   await expect(cells.nth(2)).not.toHaveClass(/run-through-code-result__success/);
-  await expect(cells.nth(2)).not.toHaveClass(/run-through-code-code/);
+  await expect(cells.nth(2)).not.toHaveClass(/run-through-code-result__error/);
 
   // click collapse heading button (open)
   await page.hover('.jp-InputArea-prompt');


### PR DESCRIPTION
## Summary

The assertion was checking for `run-through-code-code`, which doesn't exist as a class name, so `not.toHaveClass` always passed regardless of the cell state.

Replaced it with `run-through-code-result__error` so the test actually verifies that the cell is not in an error state.